### PR TITLE
Feature/pedigree class

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -1,0 +1,30 @@
+const {
+  Pedigree,
+  DiseaseFactory,
+  FamilyMemberFactory,
+  genders: { MALE, FEMALE },
+  inheritances,
+} = require('../dist/index.cjs');
+
+const me = FamilyMemberFactory.create('나', MALE, null);
+const I = me;
+
+const dad = FamilyMemberFactory.create('아버지', MALE, null);
+const mom = FamilyMemberFactory.create('어머니', FEMALE, false);
+dad.marry(mom);
+mom.has.son(me); // if female, use daughter
+
+const grandMother1 = FamilyMemberFactory.create('할머니', FEMALE, null);
+const grandFather1 = FamilyMemberFactory.create('할아버지', MALE, true);
+grandFather1.marry(grandMother1);
+grandFather1.has.son(dad);
+
+const grandMother2 = FamilyMemberFactory.create('외할머니', FEMALE, null);
+const grandFather2 = FamilyMemberFactory.create('외할아버지', MALE);
+grandMother2.marry(grandFather2);
+grandFather2.has.daughter(mom);
+
+const disease = DiseaseFactory.create('질환명', inheritances.X_RECESSIVE);
+
+const pd = new Pedigree(disease, me);
+console.dir(pd.calculateProbabilities(), { depth: null });

--- a/lib/const/genotype.ts
+++ b/lib/const/genotype.ts
@@ -32,14 +32,14 @@ const choices = new Set(genotypeList);
 export type Genotype = typeof genotypeList[number];
 
 const AUTOSOMAL = Object.freeze([
-  HOMOZYGOUS_DOMINANT,
-  HETEROZYGOUS,
   HOMOZYGOUS_RECESSIVE,
+  HETEROZYGOUS,
+  HOMOZYGOUS_DOMINANT,
 ]) as Genotype[];
 const X_FEMALE = AUTOSOMAL;
 const X_MALE = Object.freeze([
-  HEMIZYGOUS_DOMINANT,
   HEMIZYGOUS_RECESSIVE,
+  HEMIZYGOUS_DOMINANT,
 ]) as Genotype[];
 const Y_FEMALE = Object.freeze([NULL]) as Genotype[];
 const Y_MALE = X_MALE;
@@ -56,6 +56,7 @@ const RECESSIVE = Object.freeze([
 export default Object.freeze({
   DOMINANT_ALLELE,
   RECESSIVE_ALLELE,
+  NULL_ALLELE,
   HOMOZYGOUS_DOMINANT,
   HETEROZYGOUS,
   HOMOZYGOUS_RECESSIVE,

--- a/lib/const/inheritance.ts
+++ b/lib/const/inheritance.ts
@@ -17,6 +17,7 @@ export default Object.freeze({
   XD,
   X_RECESSIVE: XR,
   XR,
+  X_SEMIDOMINANT: 'XS', // heterozygotes have milder and more variable phenotype than hemizygotes
   isAutosomal: (inheritance: Inheritance) => inheritance.startsWith('A'),
   isDominant: (inheritance: Inheritance) => inheritance.endsWith('D'),
   isValid: (inheritance: string) => choices.has(inheritance as Inheritance),

--- a/lib/disease/autosomal.ts
+++ b/lib/disease/autosomal.ts
@@ -1,7 +1,9 @@
 import { genotypes } from '../const';
-import type { Genotype } from '../const';
-import CommonDisease from './common';
-import type { Phenotype } from './common';
+import CommonDisease, { MAX, MIN, LIMIT, throwRangeError } from './common';
+import type { DiseaseAlleleCountRange, ParentRanges } from './common';
+import type { FamilyMember } from '../family-member';
+
+const limit = 2;
 
 /**
  * Class representing an autosomal disease

--- a/lib/disease/autosomal.ts
+++ b/lib/disease/autosomal.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { genotypes } from '../const';
 import type { Genotype } from '../const';
 import CommonDisease from './common';
@@ -11,29 +10,6 @@ import type { Phenotype } from './common';
 class AutosomalDisease extends CommonDisease {
   static _validGenotypes = genotypes.AUTOSOMAL;
 
-  getValidGenotypes() {
-    return AutosomalDisease._validGenotypes;
-  }
-
-  hasValidGenotypes({ genotypes: list }: { genotypes: Genotype[] }) {
-    if (!Array.isArray(list) || !list.length) return false;
-
-    const genotypeSet = new Set(list);
-    if (genotypeSet.size !== list.length) return false; // duplicate check
-
-    AutosomalDisease._validGenotypes.forEach((genotype) =>
-      genotypeSet.delete(genotype),
-    );
-    return genotypeSet.size === 0; // if not 0, it has invalid genotype
-  }
-
-  getPossibleGenotypes({ phenotype }: { phenotype: Phenotype }) {
-    const { _validGenotypes: validGenotypes } = AutosomalDisease;
-    if (typeof phenotype !== 'boolean') return validGenotypes;
-    return validGenotypes.filter(
-      (genotype: Genotype) => super.hasDisease(genotype) === phenotype,
-    );
-  }
 }
 
 export default AutosomalDisease;

--- a/lib/disease/autosomal.ts
+++ b/lib/disease/autosomal.ts
@@ -40,7 +40,7 @@ class AutosomalDisease extends CommonDisease {
     /* using childRange[MIN] */
     if (childMin > parentRanges.filter((range) => range[MAX] !== 0).length)
       throw new Error(
-        'child has more disease alleles than parents would inherit at most',
+        'child has more disease alleles than parents would inherit at most.',
       );
 
     if (childMin === 2) {
@@ -62,7 +62,7 @@ class AutosomalDisease extends CommonDisease {
       parentRanges.filter((range) => range[MIN] === range[LIMIT]).length
     )
       throw new Error(
-        'child has less diseases alleles than parent would inherit at least',
+        'child has less diseases alleles than parent would inherit at least.',
       );
 
     if (childMax === 0) {

--- a/lib/disease/autosomal.ts
+++ b/lib/disease/autosomal.ts
@@ -41,7 +41,6 @@ class AutosomalDisease extends CommonDisease {
     const [childMin, childMax] = childRange;
     const [fatherRange, motherRange] = parentRanges;
 
-    /* using childRange[MIN] */
     if (childMin > parentRanges.filter(mayInheritAllele).length)
       throw new Error(
         'child has more disease alleles than parents would inherit at most.',
@@ -50,14 +49,9 @@ class AutosomalDisease extends CommonDisease {
     if (childMin === 2) {
       // all parents should have at lease one disease allele
       parentRanges.forEach(shouldHaveDiseaseAllele);
-    } else if (childMin === 1) {
-      // if one parent does not have disease allele, it should come from the other one
-      if (!mayInheritAllele(fatherRange)) shouldHaveDiseaseAllele(motherRange);
-      else if (!mayInheritAllele(motherRange))
-        shouldHaveDiseaseAllele(fatherRange);
+      return;
     }
 
-    /* using childRange[MAX] */
     if (childMax < parentRanges.filter(willInheritAllele).length)
       throw new Error(
         'child has less diseases alleles than parent would inherit at least.',
@@ -66,7 +60,17 @@ class AutosomalDisease extends CommonDisease {
     if (childMax === 0) {
       // all parents should have at lease one wild-type allele
       parentRanges.forEach(shouldHaveWildTypeAllele);
-    } else if (childMax === 1) {
+      return;
+    }
+
+    if (childMin === 1) {
+      // if one parent does not have disease allele, it should come from the other one
+      if (!mayInheritAllele(fatherRange)) shouldHaveDiseaseAllele(motherRange);
+      else if (!mayInheritAllele(motherRange))
+        shouldHaveDiseaseAllele(fatherRange);
+    }
+
+    if (childMax === 1) {
       // if one parent does not have wild-type allele, it should come from the other one
       if (willInheritAllele(fatherRange)) shouldHaveWildTypeAllele(motherRange);
       else if (willInheritAllele(motherRange))

--- a/lib/disease/autosomal.ts
+++ b/lib/disease/autosomal.ts
@@ -46,20 +46,14 @@ class AutosomalDisease extends CommonDisease {
     if (childMin === 2) {
       // all parents should have at lease one disease allele
       parentRanges.forEach((range) => {
-        if (range[MIN] === 0) {
-          range[MIN] = 1;
-          if (range[MAX] === 0) throwRangeError();
-        }
+        if (range[MIN] === 0) range[MIN] = 1;
       });
     } else if (childMin === 1) {
       // if one parent does not have disease allele, it should come from the other one
-      const motherMaxZero = motherRange[MAX] === 0;
       if (fatherRange[MAX] === 0) {
-        if (motherRange[MIN] === 0) {
-          motherRange[MIN] = 1;
-          if (motherMaxZero) throwRangeError();
-        }
-      } else if (motherMaxZero && fatherRange[MIN] === 0) fatherRange[MIN] = 1;
+        if (motherRange[MIN] === 0) motherRange[MIN] = 1;
+      } else if (motherRange[MAX] === 0 && fatherRange[MIN] === 0)
+        fatherRange[MIN] = 1;
     }
 
     /* using childRange[MAX] */
@@ -74,20 +68,16 @@ class AutosomalDisease extends CommonDisease {
     if (childMax === 0) {
       // all parents should have at lease one wild-type allele
       parentRanges.forEach((range) => {
-        if (range[MAX] === range[LIMIT]) {
-          range[MAX] = 1;
-          if (range[MIN] === 2) throwRangeError();
-        }
+        if (range[MAX] === range[LIMIT]) range[MAX] = 1;
       });
     } else if (childMax === 1) {
       // if one parent does not have wild-type allele, it should come from the other one
-      const motherMinLimit = motherRange[MIN] === limit;
       if (fatherRange[MIN] === fatherRange[LIMIT]) {
         if (motherRange[MAX] === 2) {
           motherRange[MAX] = 1;
-          if (motherMinLimit) throwRangeError();
         }
-      } else if (motherMinLimit && fatherRange[MAX] === 2) fatherRange[MAX] = 1;
+      } else if (motherRange[MIN] === limit && fatherRange[MAX] === 2)
+        fatherRange[MAX] = 1;
     }
   };
 
@@ -107,7 +97,7 @@ class AutosomalDisease extends CommonDisease {
   _getGenotypesFromRange = ([min, max]: DiseaseAlleleCountRange) => {
     max++; // exclusive
     if (!this._isDominant) {
-      const temp = -(max as number);
+      const temp = -max;
       max = (-min || undefined) as number;
       min = temp;
     }

--- a/lib/disease/autosomal.ts
+++ b/lib/disease/autosomal.ts
@@ -12,6 +12,107 @@ const limit = 2;
 class AutosomalDisease extends CommonDisease {
   static _validGenotypes = genotypes.AUTOSOMAL;
 
+  static _updateRangeFromParents = (
+    parentRanges: ParentRanges,
+    childRange: DiseaseAlleleCountRange,
+  ) => {
+    const range = [
+      // always gets disease allele if parent only has disease alleles
+      parentRanges.filter((parentRange) => parentRange[MIN] === limit).length,
+
+      // never gets disease allele if parent does not have disease allele
+      parentRanges.filter((parentRange) => parentRange[MAX] !== 0).length,
+
+      limit,
+    ] as DiseaseAlleleCountRange;
+    if (range[MIN] > childRange[MIN]) childRange[MIN] = range[MIN];
+    if (range[MAX] < childRange[MAX]) childRange[MAX] = range[MAX];
+    if (childRange[MIN] > childRange[MAX]) throwRangeError();
+  };
+
+  static _updateRangeFromChild = (
+    parentRanges: ParentRanges,
+    childRange: DiseaseAlleleCountRange,
+  ) => {
+    const [childMin, childMax] = childRange;
+    const [fatherRange, motherRange] = parentRanges;
+
+    /* using childRange[MIN] */
+    if (childMin > parentRanges.filter((range) => range[MAX] !== 0).length)
+      throw new Error(
+        'child has more disease alleles than parents would inherit at most',
+      );
+
+    if (childMin === 2) {
+      // all parents should have at lease one disease allele
+      parentRanges.forEach((range) => {
+        if (range[MIN] === 0) {
+          range[MIN] = 1;
+          if (range[MAX] === 0) throwRangeError();
+        }
+      });
+    } else if (childMin === 1) {
+      // if one parent does not have disease allele, it should come from the other one
+      const motherMaxZero = motherRange[MAX] === 0;
+      if (fatherRange[MAX] === 0) {
+        if (motherRange[MIN] === 0) {
+          motherRange[MIN] = 1;
+          if (motherMaxZero) throwRangeError();
+        }
+      } else if (motherMaxZero && fatherRange[MIN] === 0) fatherRange[MIN] = 1;
+    }
+
+    /* using childRange[MAX] */
+    if (
+      childMax <
+      parentRanges.filter((range) => range[MIN] === range[LIMIT]).length
+    )
+      throw new Error(
+        'child has less diseases alleles than parent would inherit at least',
+      );
+
+    if (childMax === 0) {
+      // all parents should have at lease one wild-type allele
+      parentRanges.forEach((range) => {
+        if (range[MAX] === range[LIMIT]) {
+          range[MAX] = 1;
+          if (range[MIN] === 2) throwRangeError();
+        }
+      });
+    } else if (childMax === 1) {
+      // if one parent does not have wild-type allele, it should come from the other one
+      const motherMinLimit = motherRange[MIN] === limit;
+      if (fatherRange[MIN] === fatherRange[LIMIT]) {
+        if (motherRange[MAX] === 2) {
+          motherRange[MAX] = 1;
+          if (motherMinLimit) throwRangeError();
+        }
+      } else if (motherMinLimit && fatherRange[MAX] === 2) fatherRange[MAX] = 1;
+    }
+  };
+
+  _getRangeFromPhenotype = ({ phenotype }: FamilyMember) =>
+    [
+      phenotype ? (this._isDominant ? 1 : 2) : 0,
+      phenotype === false ? (this._isDominant ? 0 : 1) : limit,
+      limit,
+    ] as DiseaseAlleleCountRange;
+
+  _updateRangeFromParents = AutosomalDisease._updateRangeFromParents;
+
+  _updateRangeFromSon = AutosomalDisease._updateRangeFromChild;
+
+  _updateRangeFromDaughter = AutosomalDisease._updateRangeFromChild;
+
+  _getGenotypesFromRange = ([min, max]: DiseaseAlleleCountRange) => {
+    max++; // exclusive
+    if (!this._isDominant) {
+      const temp = -(max as number);
+      max = (-min || undefined) as number;
+      min = temp;
+    }
+    return AutosomalDisease._validGenotypes.slice(min, max);
+  };
 }
 
 export default AutosomalDisease;

--- a/lib/disease/common.ts
+++ b/lib/disease/common.ts
@@ -1,5 +1,5 @@
 import { inheritances, genotypes } from '../const';
-import type { Allele, Genotype, Inheritance } from '../const';
+import type { Genotype, Inheritance } from '../const';
 import type { FamilyMember } from '../family-member';
 
 export const MIN = 0;

--- a/lib/disease/common.ts
+++ b/lib/disease/common.ts
@@ -1,9 +1,18 @@
 import { inheritances, genotypes } from '../const';
-import type { Allele, Gender, Genotype, Inheritance } from '../const';
+import type { Allele, Genotype, Inheritance } from '../const';
+import type { FamilyMember } from '../family-member';
 
+export const MIN = 0;
+export const MAX = 1;
+export const LIMIT = 2;
+export const throwRangeError = () => {
+  throw new Error('range[MAX] cannot be less than range[MIN]');
 };
 
 export type Phenotype = boolean | null;
+
+export type DiseaseAlleleCountRange = [number, number, number]; // [min, max, limit]
+export type ParentRanges = [DiseaseAlleleCountRange, DiseaseAlleleCountRange]; // [father, mother]
 
 export interface Disease {
   name: string;

--- a/lib/disease/common.ts
+++ b/lib/disease/common.ts
@@ -28,6 +28,30 @@ abstract class CommonDisease implements Disease {
 
   _isDominant: boolean;
 
+  abstract _getRangeFromPhenotype: (
+    member: FamilyMember,
+  ) => DiseaseAlleleCountRange;
+
+  abstract _updateRangeFromParents: (
+    parentRanges: ParentRanges,
+    childRange: DiseaseAlleleCountRange,
+    { _isMale }: FamilyMember,
+  ) => void;
+
+  abstract _updateRangeFromSon: (
+    parentRanges: ParentRanges,
+    sonRange: DiseaseAlleleCountRange,
+  ) => void;
+
+  abstract _updateRangeFromDaughter: (
+    parentRanges: ParentRanges,
+    daughterRange: DiseaseAlleleCountRange,
+  ) => void;
+
+  abstract _getGenotypesFromRange: (
+    range: DiseaseAlleleCountRange,
+    { gender }: FamilyMember,
+  ) => Genotype[];
 
   /**
    * Creates an abstract disease with name and inheritance

--- a/lib/disease/common.ts
+++ b/lib/disease/common.ts
@@ -77,8 +77,7 @@ abstract class CommonDisease implements Disease {
   }
 
   hasDisease(genotype: Genotype) {
-    return genotype.includes(this._diseaseAllele);
-  }
+    return this._isDominant === genotype.includes(genotypes.DOMINANT_ALLELE);
   }
 }
 

--- a/lib/disease/common.ts
+++ b/lib/disease/common.ts
@@ -4,9 +4,28 @@ import type { FamilyMember } from '../family-member';
 
 export const MIN = 0;
 export const MAX = 1;
-export const LIMIT = 2;
+const LIMIT = 2;
 export const throwRangeError = () => {
   throw new Error('range[MAX] cannot be less than range[MIN].');
+};
+// always gets disease allele if parent only has disease alleles
+export const willInheritAllele = (parentRange: DiseaseAlleleCountRange) =>
+  parentRange[MIN] === parentRange[LIMIT];
+
+// never gets disease allele if parent does not have disease allele
+export const mayInheritAllele = (parentRange: DiseaseAlleleCountRange) =>
+  parentRange[MAX] !== 0;
+
+export const shouldHaveDiseaseAllele = (
+  parentRange: DiseaseAlleleCountRange,
+) => {
+  if (parentRange[MIN] === 0) parentRange[MIN]++;
+};
+
+export const shouldHaveWildTypeAllele = (
+  parentRange: DiseaseAlleleCountRange,
+) => {
+  if (parentRange[MAX] === parentRange[LIMIT]) parentRange[MAX]--;
 };
 
 export type Phenotype = boolean | null;

--- a/lib/disease/common.ts
+++ b/lib/disease/common.ts
@@ -6,7 +6,7 @@ export const MIN = 0;
 export const MAX = 1;
 export const LIMIT = 2;
 export const throwRangeError = () => {
-  throw new Error('range[MAX] cannot be less than range[MIN]');
+  throw new Error('range[MAX] cannot be less than range[MIN].');
 };
 
 export type Phenotype = boolean | null;

--- a/lib/disease/common.ts
+++ b/lib/disease/common.ts
@@ -1,8 +1,6 @@
 import { inheritances, genotypes } from '../const';
 import type { Allele, Gender, Genotype, Inheritance } from '../const';
 
-export type ChildrenProbabilities = {
-  [genotype: string]: number; // type of genotype is Genotype
 };
 
 export type Phenotype = boolean | null;
@@ -11,51 +9,16 @@ export interface Disease {
   name: string;
   inheritance: Inheritance;
   isDominant: boolean;
-  getValidGenotypes: ({ gender }: { gender?: Gender }) => Genotype[];
-  hasValidGenotypes: ({
-    gender,
-    genotypes: list,
-  }: {
-    gender: Gender;
-    genotypes: Genotype[];
-  }) => boolean;
-  getPhenotype: ({ genotypes: list }: { genotypes: Genotype[] }) => Phenotype;
   hasDisease: (genotype: Genotype) => boolean;
-  getPossibleGenotypes: ({
-    gender,
-    phenotype,
-  }: {
-    gender: Gender;
-    phenotype: Phenotype;
-  }) => Genotype[];
 }
 
 abstract class CommonDisease implements Disease {
-  abstract getValidGenotypes({ gender }: { gender?: Gender }): Genotype[];
-
-  abstract hasValidGenotypes({
-    gender,
-    genotypes: list,
-  }: {
-    gender: Gender;
-    genotypes: Genotype[];
-  }): boolean;
-
-  abstract getPossibleGenotypes({
-    gender,
-    phenotype,
-  }: {
-    gender: Gender;
-    phenotype: Phenotype;
-  }): Genotype[];
-
   _name: string;
 
   _inheritance: Inheritance;
 
   _isDominant: boolean;
 
-  _diseaseAllele: Allele;
 
   /**
    * Creates an abstract disease with name and inheritance
@@ -66,8 +29,6 @@ abstract class CommonDisease implements Disease {
     this._name = name;
     this._inheritance = inheritance;
     this._isDominant = inheritances.isDominant(inheritance);
-    this._diseaseAllele =
-      genotypes[this._isDominant ? 'DOMINANT_ALLELE' : 'RECESSIVE_ALLELE'];
   }
 
   get name() {
@@ -82,58 +43,9 @@ abstract class CommonDisease implements Disease {
     return this._isDominant;
   }
 
-  getPhenotype({ genotypes: list }: { genotypes: Genotype[] }) {
-    let yes = false;
-    let no = false;
-    list.forEach((genotype) => {
-      if (this.hasDisease(genotype)) yes = true;
-      else no = true;
-    });
-    return yes ? (no ? null : true) : false;
-  }
-
   hasDisease(genotype: Genotype) {
     return genotype.includes(this._diseaseAllele);
   }
-
-  static _getProbabilitiesFromGenotypes(
-    motherGenotype: Genotype,
-    fatherGenotype: Genotype,
-  ) {
-    const cases = motherGenotype.length * fatherGenotype.length;
-    const probabilities = {} as ChildrenProbabilities;
-    motherGenotype.split('').forEach((motherAllele) => {
-      fatherGenotype.split('').forEach((fatherAllele) => {
-        const genotype =
-          motherAllele > fatherAllele // sort alleles ASC
-            ? `${fatherAllele}${motherAllele}`
-            : `${motherAllele}${fatherAllele}`;
-        if (probabilities[genotype] === undefined) probabilities[genotype] = 0;
-        probabilities[genotype] += 1 / cases;
-      });
-    });
-    return probabilities;
-  }
-
-  _calculateDiseaseProbability({
-    mother: motherGenotype,
-    father: fatherGenotype,
-  }: {
-    mother: Genotype;
-    father: Genotype;
-  }) {
-    return Object.entries(
-      CommonDisease._getProbabilitiesFromGenotypes(
-        motherGenotype,
-        fatherGenotype,
-      ),
-    ).reduce(
-      (diseaseProbability, [genotype, probability]) =>
-        this.hasDisease(genotype as Genotype)
-          ? diseaseProbability + probability
-          : diseaseProbability,
-      0,
-    );
   }
 }
 

--- a/lib/disease/x-linked.ts
+++ b/lib/disease/x-linked.ts
@@ -1,7 +1,8 @@
 import { genotypes } from '../const';
-import type { Gender, Genotype } from '../const';
-import CommonDisease from './common';
-import type { Phenotype } from './common';
+import CommonDisease, { MAX, MIN, throwRangeError } from './common';
+import AutosomalDisease from './autosomal';
+import type { DiseaseAlleleCountRange, ParentRanges } from './common';
+import type { FamilyMember } from '../family-member';
 
 /**
  * Class representing a X-linked disease

--- a/lib/disease/x-linked.ts
+++ b/lib/disease/x-linked.ts
@@ -36,13 +36,13 @@ class XLinkedDisease extends CommonDisease {
   ) => {
     if (sonRange[MIN] === 1) {
       if (motherRange[MAX] === 0)
-        throw new Error('son has disease alleles where mother does not');
+        throw new Error('son has disease alleles where mother does not.');
       if (motherRange[MIN] === 0) motherRange[MIN] = 1;
       return;
     }
     if (motherRange[MIN] === 2)
       throw new Error(
-        'son does not have disease allele where mother only has disease alleles',
+        'son does not have disease allele where mother only has disease alleles.',
       );
     if (motherRange[MAX] === 2) motherRange[MAX] = 1;
   };

--- a/lib/disease/x-linked.ts
+++ b/lib/disease/x-linked.ts
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import { genotypes } from '../const';
 import type { Gender, Genotype } from '../const';
 import CommonDisease from './common';
@@ -11,46 +10,6 @@ import type { Phenotype } from './common';
 class XLinkedDisease extends CommonDisease {
   static _validGenotypes = genotypes.byGender;
 
-  getValidGenotypes({ gender }: { gender: Gender }) {
-    const list = XLinkedDisease._validGenotypes[gender];
-    if (!list) throw new Error(`gender '${gender}' is invalid.`);
-    return list;
-  }
-
-  hasValidGenotypes({
-    gender,
-    genotypes: list,
-  }: {
-    gender: Gender;
-    genotypes: Genotype[];
-  }) {
-    if (!Array.isArray(list) || !list.length) return false;
-
-    const genotypeSet = new Set(list);
-    if (genotypeSet.size !== list.length) return false;
-
-    (XLinkedDisease._validGenotypes[gender] ?? []).forEach((genotype) =>
-      genotypeSet.delete(genotype),
-    );
-    return genotypeSet.size === 0; // if not 0, has invalid genotypes
-  }
-
-  getPossibleGenotypes({
-    gender,
-    phenotype,
-  }: {
-    gender: Gender;
-    phenotype: Phenotype;
-  }) {
-    const list = this.getValidGenotypes({ gender });
-    const filter = phenotype
-      ? (genotype: Genotype) => super.hasDisease(genotype)
-      : phenotype === false
-      ? (genotype: Genotype) => !super.hasDisease(genotype)
-      : null;
-    if (filter) return list.filter(filter);
-    return list;
-  }
 }
 
 export default XLinkedDisease;

--- a/lib/disease/x-linked.ts
+++ b/lib/disease/x-linked.ts
@@ -1,5 +1,13 @@
 import { genotypes } from '../const';
-import CommonDisease, { MAX, MIN, throwRangeError } from './common';
+import CommonDisease, {
+  MAX,
+  MIN,
+  throwRangeError,
+  willInheritAllele,
+  mayInheritAllele,
+  shouldHaveDiseaseAllele,
+  shouldHaveWildTypeAllele,
+} from './common';
 import AutosomalDisease from './autosomal';
 import type { DiseaseAlleleCountRange, ParentRanges } from './common';
 import type { FamilyMember } from '../family-member';
@@ -35,16 +43,18 @@ class XLinkedDisease extends CommonDisease {
     sonRange: DiseaseAlleleCountRange,
   ) => {
     if (sonRange[MIN] === 1) {
-      if (motherRange[MAX] === 0)
+      if (!mayInheritAllele(motherRange))
         throw new Error('son has disease alleles where mother does not.');
-      if (motherRange[MIN] === 0) motherRange[MIN] = 1;
+      shouldHaveDiseaseAllele(motherRange);
       return;
     }
-    if (motherRange[MIN] === 2)
-      throw new Error(
-        'son does not have disease allele where mother only has disease alleles.',
-      );
-    if (motherRange[MAX] === 2) motherRange[MAX] = 1;
+    if (sonRange[MAX] === 0) {
+      if (willInheritAllele(motherRange))
+        throw new Error(
+          'son does not have disease allele where mother only has disease alleles.',
+        );
+      shouldHaveWildTypeAllele(motherRange);
+    }
   };
 
   _getRangeFromPhenotype = ({ phenotype, _isMale, gender }: FamilyMember) => {

--- a/lib/disease/x-linked.ts
+++ b/lib/disease/x-linked.ts
@@ -1,4 +1,4 @@
-import { genotypes } from '../const';
+import { genotypes, inheritances } from '../const';
 import CommonDisease, {
   MAX,
   MIN,
@@ -60,7 +60,13 @@ class XLinkedDisease extends CommonDisease {
   _getRangeFromPhenotype = ({ phenotype, _isMale, gender }: FamilyMember) => {
     const limit = XLinkedDisease._validGenotypes[gender].length - 1;
     return [
-      phenotype ? (_isMale || this._isDominant ? 1 : 2) : 0,
+      phenotype
+        ? _isMale ||
+          this._isDominant ||
+          this._inheritance === inheritances.X_SEMIDOMINANT
+          ? 1
+          : 2
+        : 0,
       phenotype === false ? (_isMale || this._isDominant ? 0 : 1) : limit,
       limit,
     ] as DiseaseAlleleCountRange;

--- a/lib/disease/x-linked.ts
+++ b/lib/disease/x-linked.ts
@@ -44,7 +44,7 @@ class XLinkedDisease extends CommonDisease {
   ) => {
     if (sonRange[MIN] === 1) {
       if (!mayInheritAllele(motherRange))
-        throw new Error('son has disease alleles where mother does not.');
+        throw new Error('son has disease allele where mother does not.');
       shouldHaveDiseaseAllele(motherRange);
       return;
     }

--- a/lib/disease/x-linked.ts
+++ b/lib/disease/x-linked.ts
@@ -11,6 +11,63 @@ import type { FamilyMember } from '../family-member';
 class XLinkedDisease extends CommonDisease {
   static _validGenotypes = genotypes.byGender;
 
+  static updateRangeFromParents = (
+    [fatherRange, motherRange]: ParentRanges,
+    childRange: DiseaseAlleleCountRange,
+    { _isMale }: FamilyMember,
+  ) => {
+    const motherHasMin = motherRange[MIN] && 1;
+    const motherHasMax = motherRange[MAX] && 1;
+    const range = (_isMale
+      ? [motherHasMin, motherHasMax, 1]
+      : [
+          fatherRange[MIN] + motherHasMin,
+          fatherRange[MAX] + motherHasMax,
+          2,
+        ]) as DiseaseAlleleCountRange;
+    if (range[MIN] > childRange[MIN]) childRange[MIN] = range[MIN];
+    if (range[MAX] < childRange[MAX]) childRange[MAX] = range[MAX];
+    if (childRange[MIN] > childRange[MAX]) throwRangeError();
+  };
+
+  static _updateRangeFromSon = (
+    [_, motherRange]: ParentRanges,
+    sonRange: DiseaseAlleleCountRange,
+  ) => {
+    if (sonRange[MIN] === 1) {
+      if (motherRange[MAX] === 0)
+        throw new Error('son has disease alleles where mother does not');
+      if (motherRange[MIN] === 0) motherRange[MIN] = 1;
+      return;
+    }
+    if (motherRange[MIN] === 2)
+      throw new Error(
+        'son does not have disease allele where mother only has disease alleles',
+      );
+    if (motherRange[MAX] === 2) motherRange[MAX] = 1;
+  };
+
+  _getRangeFromPhenotype = ({ phenotype, _isMale, gender }: FamilyMember) => {
+    const limit = XLinkedDisease._validGenotypes[gender].length - 1;
+    return [
+      phenotype ? (_isMale || this._isDominant ? 1 : 2) : 0,
+      phenotype === false ? (_isMale || this._isDominant ? 0 : 1) : limit,
+      limit,
+    ] as DiseaseAlleleCountRange;
+  };
+
+  _updateRangeFromParents = XLinkedDisease.updateRangeFromParents;
+
+  _updateRangeFromSon = XLinkedDisease._updateRangeFromSon;
+
+  _updateRangeFromDaughter = AutosomalDisease._updateRangeFromChild; // can use same logic
+
+  _getGenotypesFromRange = (
+    [min, max]: DiseaseAlleleCountRange,
+    { gender }: FamilyMember,
+  ) => {
+    return XLinkedDisease._validGenotypes[gender].slice(min, max + 1);
+  };
 }
 
 export default XLinkedDisease;

--- a/lib/family-member/common.ts
+++ b/lib/family-member/common.ts
@@ -64,6 +64,10 @@ const genderByRelationship = {
   },
 };
 
+/**
+ * Class representing a family member including its phenotype and relationships
+ * @class
+ */
 class FamilyMember {
   _id: string | number;
 
@@ -257,6 +261,10 @@ class FamilyMember {
 
   get gender() {
     return this._gender;
+  }
+
+  get phenotype() {
+    return this._phenotype;
   }
 
   get mom() {

--- a/lib/pedigree/index.ts
+++ b/lib/pedigree/index.ts
@@ -161,18 +161,20 @@ class Pedigree {
     ] as ParentRanges;
 
     // analyze from children
-    Object.values(mom.sons).forEach((son) =>
-      _disease._updateRangeFromSon(
-        parentRanges,
-        _disease._getRangeFromPhenotype(son),
-      ),
-    );
-    Object.values(dad.daughters).forEach((daughter) =>
-      _disease._updateRangeFromDaughter(
-        parentRanges,
-        _disease._getRangeFromPhenotype(daughter),
-      ),
-    );
+    Object.values(mom.sons).forEach((son) => {
+      if (son.phenotype !== null)
+        _disease._updateRangeFromSon(
+          parentRanges,
+          _disease._getRangeFromPhenotype(son),
+        );
+    });
+    Object.values(dad.daughters).forEach((daughter) => {
+      if (daughter.phenotype !== null)
+        _disease._updateRangeFromDaughter(
+          parentRanges,
+          _disease._getRangeFromPhenotype(daughter),
+        );
+    });
 
     // analyze from parents
     parentRanges.forEach((parentRange, index) => {

--- a/lib/pedigree/index.ts
+++ b/lib/pedigree/index.ts
@@ -43,6 +43,34 @@ class Pedigree {
     (motherAllele > fatherAllele // sort alleles ASC
       ? `${fatherAllele}${motherAllele}`
       : `${motherAllele}${fatherAllele}`) as Genotype;
+  calculateProbabilities() {
+    try {
+      const { _disease, _target } = this;
+      if (!_target.mom || !_target.dad)
+        throw new Error('target must have parents for pedigree-analysis.');
+
+      const [fatherRange, motherRange] = this._analyze(_target);
+      const motherGenotypes = _disease._getGenotypesFromRange(
+        motherRange,
+        _target.mom,
+      );
+      const fatherGenotypes = _disease._getGenotypesFromRange(
+        fatherRange,
+        _target.dad,
+      );
+
+      return (inheritances.isAutosomal(_disease.inheritance)
+        ? Pedigree._calculateAutosomalProbabilities
+        : Pedigree._calculateSexLinkedProbabilities)(
+        motherGenotypes,
+        fatherGenotypes,
+        _disease,
+      );
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  }
 }
 
 export default Pedigree;

--- a/lib/pedigree/index.ts
+++ b/lib/pedigree/index.ts
@@ -30,7 +30,7 @@ class Pedigree {
 
   constructor(disease: CommonDisease, target: FamilyMember) {
     if (!(disease instanceof CommonDisease))
-      throw new Error('diease must be instance created by DiseaseFactory.');
+      throw new Error('disease must be instance created by DiseaseFactory.');
     if (!FamilyMemberFactory._isInstance(target))
       throw new Error(
         'target must be instance created by FamilyMemberFactory.',

--- a/lib/pedigree/index.ts
+++ b/lib/pedigree/index.ts
@@ -5,6 +5,10 @@ import FamilyMemberFactory from '../family-member';
 import type { Genotype, Allele } from '../const';
 import type { FamilyMember } from '../family-member';
 
+type Probabilities = {
+  [genotype: string]: number; // type of genotype is Genotype
+};
+
 class Pedigree {
   _disease: CommonDisease;
 
@@ -22,6 +26,23 @@ class Pedigree {
     this._target = target;
     this._genotypes = {};
   }
+
+  static _calculateDisease = (
+    probabilities: Probabilities,
+    disease: CommonDisease,
+  ) =>
+    Object.entries(probabilities).reduce(
+      (diseaseProbability, [genotype, probability]) =>
+        disease.hasDisease(genotype as Genotype)
+          ? diseaseProbability + probability
+          : diseaseProbability,
+      0,
+    );
+
+  static _getGenotype = (fatherAllele: Allele, motherAllele: Allele) =>
+    (motherAllele > fatherAllele // sort alleles ASC
+      ? `${fatherAllele}${motherAllele}`
+      : `${motherAllele}${fatherAllele}`) as Genotype;
 }
 
 export default Pedigree;

--- a/lib/pedigree/index.ts
+++ b/lib/pedigree/index.ts
@@ -1,3 +1,27 @@
-class Pedigree {}
+import { genotypes, inheritances } from '../const';
+import CommonDisease, { ParentRanges } from '../disease/common';
+import FamilyMemberFactory from '../family-member';
+
+import type { Genotype, Allele } from '../const';
+import type { FamilyMember } from '../family-member';
+
+class Pedigree {
+  _disease: CommonDisease;
+
+  _target: FamilyMember;
+
+  constructor(disease: CommonDisease, target: FamilyMember) {
+    if (!(disease instanceof CommonDisease))
+      throw new Error('diease must be instance created by DiseaseFactory.');
+    if (!FamilyMemberFactory._isInstance(target))
+      throw new Error(
+        'target must be instance created by FamilyMemberFactory.',
+      );
+
+    this._disease = disease;
+    this._target = target;
+    this._genotypes = {};
+  }
+}
 
 export default Pedigree;


### PR DESCRIPTION
개요
* Disease 계열 클래스 미사용 로직 제거 (기존 설계와 달라짐)
* Pedigree class 구현 - 질환과 분석 대상으로 instance를 생성하고 calculateProbabilities 함수를 호출하여 분석
  * 호출 시점에 있는 데이터로 분석하며, 가족(FamilyMember)의 질환 여부나 관계를 수정해도 가계도 새로 생성하지 않고 반영 가능
  * 분석 대상의 부모님의 유전형을 최대한 구체적으로 추론하여 분석 대상의 부모님에서 나올 수 있는 자녀의 확률 데이터를 반환
  * 유전형을 알고 싶은 대상의 분석은 자녀로부터 추론 -> 부모로부터 추론(부모님이 정의된 경우 재귀호출) 형태로 이루어짐

분석 로직 요약
* **가정 1: 자녀의 유전형의 범위는 질환 대립유전자의 개수에 대해 연속적임**
  * 자녀의 질환 대립유전자 개수가 0, 2개는 가능해도 1개는 불가능한 상황 없음
  * 따라서, 유전형의 범위를 나타내는 자료구조를 질환 유전자의 [최소 개수, 최대 개수, 부모/표현형 고려 안한 최대 개수]로 선택함

* **가정 2: 자녀는 부모로부터 하나씩의 대립유전자를 물려받으며, 없는 대립유전자를 받거나 반드시 받을 대립유전자를 안 받을 수는 없음**
  * 따라서, _De novo_ 변이인지는 분석 불가
  * X-연관 유전 질환의 경우, 아들은 아버지로부터 대립유전자를 물려받지 않음(Y 염색체)

----

* **추론 규칙 1: 자녀의 질환 대립유전자 개수의 최소값은 질환 대립유전자를 반드시 물려줄 부모의 수 이상임**
  * 예를 들어, 상염색체 열성 질환에서 아버지가 aa, 어머니가 A_인 경우 아버지는 반드시 질환 대립유전자를 물려주며, 어머니는 아닐 수 있음
  * 즉, 자녀는 반드시 질환 대립유전자를 한 개는 가져야 하며, 그렇지 않은 경우 이는 상염색체 열성으로 유전되지 않는 것으로 판단

* **추론 규칙 2: 자녀의 질환 대립유전자 개수의 최대값은 질환 대립유전자를 물려줄 수도 있는 부모의 수 이하임**
  * 질환 대립유전자를 물려줄 수 있는지 여부 = 질환 유전자 개수의 최대값이 0인 여부
  * 예를 들어, X-연관 우성 질환에서 아버지가 X, 어머니가 xx인 경우 질환 대립유전자의 개수가 딸은 1개, 아들은 0개임

----

* **초기값 설정 1: 상염색체 열성 질환 또는 여성의 X-연관 열성 질환의 경우 아래와 같음**
  * 질환이 있는 경우 질환 대립유전자의 개수는 정확히 2개
  * 질환이 없는 경우 질환 대립유전자의 개수는 0개 이상 1개 이하
  * 질환 여부를 모르는 경우 질환 대립유전자의 개수는 0개 이상 2개 이하

* **초기값 설정 2: 상염색체 우성 질환 또는 여성의 X-연관 우성 질환의 경우 아래와 같음**
  * 질환이 있는 경우 질환 대립유전자의 개수는 1개 이상 2개 이하
  * 질환이 없는 경우 질환 대립유전자의 개수는 정확히 0개
  * 질환 여부를 모르는 경우 질환 대립유전자의 개수는 0개 이상 2개 이하

* **초기값 설정 3: 남성의 X-연관 질환의 경우 아래와 같음**
  * 질환이 있는 경우 질환 대립유전자의 개수는 정확히 1개
  * 질환이 없는 경우 질환 대립유전자의 개수는 정확히 0개
  * 질환 여부를 모르는 경우 질환 대립유전자의 개수는 0개 이상 1개 이하

* **초기값 설정 4: 여성의 X-연관 반우성 질환의 경우 아래와 같음**
  * 질환이 있는 경우 질환 대립유전자의 개수는 1개 이상 2개 이하
  * 질환이 없는 경우 질환 대립유전자의 개수는 0개 이상 1개 이하
  * 질환 여부를 모르는 경우 질환 대립유전자의 개수는 0개 이상 2개 이하