### PR TITLE
Feature/family relationship validation

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -24,7 +24,10 @@ const grandFather2 = FamilyMemberFactory.create('외할아버지', MALE);
 grandMother2.marry(grandFather2);
 grandFather2.has.daughter(mom);
 
-const disease = DiseaseFactory.create('질환명', inheritances.X_RECESSIVE);
+const disease = DiseaseFactory.create(
+  '질환명',
+  inheritances.X_LINKED_RECESSIVE,
+);
 
 const pd = new Pedigree(disease, me);
 console.dir(pd.calculateProbabilities(), { depth: null });

--- a/lib/const/genotype.ts
+++ b/lib/const/genotype.ts
@@ -2,32 +2,47 @@ import genders from './gender';
 
 const { MALE, FEMALE } = genders;
 
-// use '|' so that 'A' < 'a' < '|' (charCode)
 const DOMINANT_ALLELE = 'A' as const;
 const RECESSIVE_ALLELE = 'a' as const;
-const NULL_ALLELE = '|' as const;
+
+const X_DOMINANT_ALLELE = 'X' as const;
+const X_RECESSIVE_ALLELE = 'x' as const;
+const Y_DOMINANT_ALLELE = 'Y' as const;
+// const Y_RECESSIVE_ALLELE = 'y' as const;
+
+// const NULL_ALLELE = '_' as const; // women do not have Y chromosome
 
 export type Allele =
   | typeof DOMINANT_ALLELE
   | typeof RECESSIVE_ALLELE
-  | typeof NULL_ALLELE;
+  | typeof X_DOMINANT_ALLELE
+  | typeof X_RECESSIVE_ALLELE
+  | typeof Y_DOMINANT_ALLELE;
+// | typeof Y_RECESSIVE_ALLELE
+// | typeof NULL_ALLELE;
 
-const HOMOZYGOUS_DOMINANT = `${DOMINANT_ALLELE}${DOMINANT_ALLELE}` as const;
-const HETEROZYGOUS = `${DOMINANT_ALLELE}${RECESSIVE_ALLELE}` as const;
-const HOMOZYGOUS_RECESSIVE = `${RECESSIVE_ALLELE}${RECESSIVE_ALLELE}` as const;
-const HEMIZYGOUS_DOMINANT = `${DOMINANT_ALLELE}${NULL_ALLELE}` as const;
-const HEMIZYGOUS_RECESSIVE = `${RECESSIVE_ALLELE}${NULL_ALLELE}` as const;
-const NULL = `${NULL_ALLELE}${NULL_ALLELE}` as const; // for example, women do not have Y chromosome
+// Autosomal
+const HOMOZYGOUS_DOMINANT = `${DOMINANT_ALLELE}${DOMINANT_ALLELE}` as const; // AA
+const HETEROZYGOUS = `${DOMINANT_ALLELE}${RECESSIVE_ALLELE}` as const; // Aa
+const HOMOZYGOUS_RECESSIVE = `${RECESSIVE_ALLELE}${RECESSIVE_ALLELE}` as const; // aa
+
+// X-linked
+const X_HOMOZYGOUS_DOMINANT = `${X_DOMINANT_ALLELE}${X_DOMINANT_ALLELE}` as const; // XX
+const X_HETEROZYGOUS = `${X_DOMINANT_ALLELE}${X_RECESSIVE_ALLELE}` as const; // Xx
+const X_HOMOZYGOUS_RECESSIVE = `${X_RECESSIVE_ALLELE}${X_RECESSIVE_ALLELE}` as const; // xx
+const X_HEMIZYGOUS_DOMINANT = `${X_DOMINANT_ALLELE}${Y_DOMINANT_ALLELE}` as const; // XY
+const X_HEMIZYGOUS_RECESSIVE = `${X_RECESSIVE_ALLELE}${Y_DOMINANT_ALLELE}` as const; // xY
 
 const genotypeList = [
   HOMOZYGOUS_DOMINANT,
   HETEROZYGOUS,
   HOMOZYGOUS_RECESSIVE,
-  HEMIZYGOUS_DOMINANT,
-  HEMIZYGOUS_RECESSIVE,
-  NULL,
+  X_HOMOZYGOUS_DOMINANT,
+  X_HETEROZYGOUS,
+  X_HOMOZYGOUS_RECESSIVE,
+  X_HEMIZYGOUS_DOMINANT,
+  X_HEMIZYGOUS_RECESSIVE,
 ] as const;
-const choices = new Set(genotypeList);
 
 export type Genotype = typeof genotypeList[number];
 
@@ -36,43 +51,35 @@ const AUTOSOMAL = Object.freeze([
   HETEROZYGOUS,
   HOMOZYGOUS_DOMINANT,
 ]) as Genotype[];
-const X_FEMALE = AUTOSOMAL;
+const X_FEMALE = Object.freeze([
+  X_HOMOZYGOUS_RECESSIVE,
+  X_HETEROZYGOUS,
+  X_HOMOZYGOUS_RECESSIVE,
+]);
 const X_MALE = Object.freeze([
-  HEMIZYGOUS_RECESSIVE,
-  HEMIZYGOUS_DOMINANT,
-]) as Genotype[];
-const Y_FEMALE = Object.freeze([NULL]) as Genotype[];
-const Y_MALE = X_MALE;
-const DOMINANT = Object.freeze([
-  HOMOZYGOUS_DOMINANT,
-  HETEROZYGOUS,
-  HEMIZYGOUS_DOMINANT,
-]) as Genotype[];
-const RECESSIVE = Object.freeze([
-  HOMOZYGOUS_RECESSIVE,
-  HEMIZYGOUS_RECESSIVE,
+  X_HEMIZYGOUS_RECESSIVE,
+  X_HEMIZYGOUS_DOMINANT,
 ]) as Genotype[];
 
 export default Object.freeze({
-  DOMINANT_ALLELE,
-  RECESSIVE_ALLELE,
-  NULL_ALLELE,
-  HOMOZYGOUS_DOMINANT,
-  HETEROZYGOUS,
-  HOMOZYGOUS_RECESSIVE,
-  HEMIZYGOUS_DOMINANT,
-  HEMIZYGOUS_RECESSIVE,
-  NULL,
   AUTOSOMAL,
-  Y_FEMALE,
-  Y_MALE,
-  X_FEMALE,
-  X_MALE,
-  DOMINANT,
-  RECESSIVE,
-  isValid: (genotype: string) => choices.has(genotype as Genotype),
-  byGender: {
+  X_LINKED: {
     [MALE]: X_MALE,
     [FEMALE]: X_FEMALE,
+  },
+  _isAlleleY: (fatherAllele: Allele) =>
+    fatherAllele.toUpperCase() === Y_DOMINANT_ALLELE,
+  _hasDominantAllele: (genotype: string) =>
+    genotype[0].toUpperCase() === genotype[0],
+  _fromAlleles: (motherAllele: Allele, fatherAllele: Allele) => {
+    const motherFirst =
+      fatherAllele === Y_DOMINANT_ALLELE || motherAllele < fatherAllele;
+    // (fatherAllele.toUpperCase() === Y_DOMINANT_ALLELE)
+    //   ? motherAllele !== NULL_ALLELE
+    //   : motherAllele < fatherAllele
+
+    return (motherFirst
+      ? `${motherAllele}${fatherAllele}`
+      : `${fatherAllele}${motherAllele}`) as Genotype;
   },
 });

--- a/lib/const/inheritance.ts
+++ b/lib/const/inheritance.ts
@@ -4,7 +4,7 @@ const XLD = 'XLD';
 const XLR = 'XLR';
 const XL = 'XL';
 
-const inheritanceList = [AD, AR, XLD, XLR] as const;
+const inheritanceList = [AD, AR, XLD, XLR, XL] as const;
 const choices = new Set(inheritanceList);
 
 export type Inheritance = typeof inheritanceList[number];

--- a/lib/const/inheritance.ts
+++ b/lib/const/inheritance.ts
@@ -1,9 +1,10 @@
 const AD = 'AD';
 const AR = 'AR';
-const XD = 'XD';
-const XR = 'XR';
+const XLD = 'XLD';
+const XLR = 'XLR';
+const XL = 'XL';
 
-const inheritanceList = [AD, AR, XD, XR] as const;
+const inheritanceList = [AD, AR, XLD, XLR] as const;
 const choices = new Set(inheritanceList);
 
 export type Inheritance = typeof inheritanceList[number];
@@ -13,11 +14,12 @@ export default Object.freeze({
   AD,
   AUTOSOMAL_RECESSIVE: AR,
   AR,
-  X_DOMINANT: XD,
-  XD,
-  X_RECESSIVE: XR,
-  XR,
-  X_SEMIDOMINANT: 'XS', // heterozygotes have milder and more variable phenotype than hemizygotes
+  X_LINKED_DOMINANT: XLD,
+  XLD,
+  X_LINKED_RECESSIVE: XLR,
+  XLR,
+  X_LINKED: XL, // carriers have ambiguous phenotype
+  XL,
   isAutosomal: (inheritance: Inheritance) => inheritance.startsWith('A'),
   isDominant: (inheritance: Inheritance) => inheritance.endsWith('D'),
   isValid: (inheritance: string) => choices.has(inheritance as Inheritance),

--- a/lib/const/inheritance.ts
+++ b/lib/const/inheritance.ts
@@ -1,8 +1,8 @@
-const AD = 'AD';
-const AR = 'AR';
-const XLD = 'XLD';
-const XLR = 'XLR';
-const XL = 'XL';
+const AD = 'AD' as const;
+const AR = 'AR' as const;
+const XLD = 'XLD' as const;
+const XLR = 'XLR' as const;
+const XL = 'XL' as const;
 
 const inheritanceList = [AD, AR, XLD, XLR, XL] as const;
 const choices = new Set(inheritanceList);

--- a/lib/disease/common.ts
+++ b/lib/disease/common.ts
@@ -96,7 +96,7 @@ abstract class CommonDisease implements Disease {
   }
 
   hasDisease(genotype: Genotype) {
-    return this._isDominant === genotype.includes(genotypes.DOMINANT_ALLELE);
+    return this._isDominant === genotypes._hasDominantAllele(genotype);
   }
 }
 

--- a/lib/disease/x-linked.ts
+++ b/lib/disease/x-linked.ts
@@ -17,7 +17,7 @@ import type { FamilyMember } from '../family-member';
  * @class
  */
 class XLinkedDisease extends CommonDisease {
-  static _validGenotypes = genotypes.byGender;
+  static _validGenotypes = genotypes.X_LINKED;
 
   static updateRangeFromParents = (
     [fatherRange, motherRange]: ParentRanges,
@@ -63,7 +63,7 @@ class XLinkedDisease extends CommonDisease {
       phenotype
         ? _isMale ||
           this._isDominant ||
-          this._inheritance === inheritances.X_SEMIDOMINANT
+          this._inheritance === inheritances.X_LINKED
           ? 1
           : 2
         : 0,

--- a/lib/disease/x-linked.ts
+++ b/lib/disease/x-linked.ts
@@ -19,7 +19,7 @@ import type { FamilyMember } from '../family-member';
 class XLinkedDisease extends CommonDisease {
   static _validGenotypes = genotypes.X_LINKED;
 
-  static updateRangeFromParents = (
+  static _updateRangeFromParents = (
     [fatherRange, motherRange]: ParentRanges,
     childRange: DiseaseAlleleCountRange,
     { _isMale }: FamilyMember,
@@ -72,7 +72,7 @@ class XLinkedDisease extends CommonDisease {
     ] as DiseaseAlleleCountRange;
   };
 
-  _updateRangeFromParents = XLinkedDisease.updateRangeFromParents;
+  _updateRangeFromParents = XLinkedDisease._updateRangeFromParents;
 
   _updateRangeFromSon = XLinkedDisease._updateRangeFromSon;
 

--- a/lib/disease/x-linked.ts
+++ b/lib/disease/x-linked.ts
@@ -82,7 +82,13 @@ class XLinkedDisease extends CommonDisease {
     [min, max]: DiseaseAlleleCountRange,
     { gender }: FamilyMember,
   ) => {
-    return XLinkedDisease._validGenotypes[gender].slice(min, max + 1);
+    max++; // exclusive
+    if (!this._isDominant) {
+      const temp = -max;
+      max = (-min || undefined) as number;
+      min = temp;
+    }
+    return XLinkedDisease._validGenotypes[gender].slice(min, max);
   };
 }
 

--- a/lib/family-member/common.ts
+++ b/lib/family-member/common.ts
@@ -140,7 +140,7 @@ class FamilyMember {
       throw new Error(`cannot have ${relationship} before getting married.`);
 
     [this, this.spouse].forEach((parent) => {
-      if (child === parent || parent.hasAncestor(child))
+      if (child.equals(parent) || parent.hasAncestor(child))
         throw new Error('child cannot be one of its ancestors.');
     });
 
@@ -291,9 +291,13 @@ class FamilyMember {
     let target: FamilyMember = this;
     while (stack.push(...getNearestAncestorsOf(target))) {
       target = stack.pop() as FamilyMember;
-      if (ancestor === target) return true;
+      if (ancestor.equals(target)) return true;
     }
     return false;
+  }
+
+  equals(member: FamilyMember) {
+    return this._id === member._id;
   }
 
   get id() {

--- a/lib/family-member/common.ts
+++ b/lib/family-member/common.ts
@@ -81,15 +81,11 @@ class FamilyMember {
 
   _relationships: Relationship;
 
-  has: Has;
+  _has: Has;
 
-  have: Has;
+  _doesNotHave: DoesNotHave;
 
-  doesNotHave: DoesNotHave;
-
-  doNotHave: DoesNotHave;
-
-  mayHave: { disease: () => void };
+  _mayHave: { disease: () => void };
 
   static _getNearestMaleAncestorsOf(target: FamilyMember) {
     const maleAncestors = [];
@@ -192,7 +188,7 @@ class FamilyMember {
 
     this._validateMember(relationship, sibling);
     if (!this.mom) throw new Error(`must have parent to have ${relationship}.`);
-    (this.mom as FamilyMember)._addChild(
+    this.mom._addChild(
       relationship === 'brother' ? 'son' : 'daughter',
       sibling,
     );
@@ -220,7 +216,7 @@ class FamilyMember {
       daughters: {},
     };
 
-    this.has = Object.freeze({
+    this._has = Object.freeze({
       disease: () => {
         this._phenotype = true;
       },
@@ -229,9 +225,8 @@ class FamilyMember {
       brother: (brother: FamilyMember) => this._hasSibling({ brother }),
       sister: (sister: FamilyMember) => this._hasSibling({ sister }),
     });
-    this.have = this.has;
 
-    this.doesNotHave = Object.freeze({
+    this._doesNotHave = Object.freeze({
       disease: () => {
         this._phenotype = false;
       },
@@ -240,9 +235,8 @@ class FamilyMember {
       brother: (brother: Id) => this._doesNotHaveSibling({ brother }),
       sister: (sister: Id) => this._doesNotHaveSibling({ sister }),
     });
-    this.doNotHave = this.doesNotHave;
 
-    this.mayHave = Object.freeze({
+    this._mayHave = Object.freeze({
       disease: () => {
         this._phenotype = null;
       },
@@ -345,6 +339,26 @@ class FamilyMember {
       dad &&
       Object.values(dad.daughters).filter((sister) => sister.id !== this.id)
     );
+  }
+
+  get has() {
+    return this._has;
+  }
+
+  get have() {
+    return this._has;
+  }
+
+  get doesNotHave() {
+    return this._doesNotHave;
+  }
+
+  get doNotHave() {
+    return this._doesNotHave;
+  }
+
+  get mayHave() {
+    return this._mayHave;
   }
 }
 

--- a/lib/family-member/common.ts
+++ b/lib/family-member/common.ts
@@ -244,7 +244,7 @@ class FamilyMember {
   }
 
   marry(spouse: FamilyMember) {
-    if (this.spouse)
+    if (this.spouse || spouse.spouse)
       throw new Error(
         'pedigree analysis is not prepared for multiple marriages... divorce first in order to marry again.',
       );

--- a/lib/family-member/common.ts
+++ b/lib/family-member/common.ts
@@ -244,15 +244,16 @@ class FamilyMember {
   }
 
   marry(spouse: FamilyMember) {
+    if (!(spouse instanceof FamilyMember) || this._isMale === spouse._isMale)
+      throw new Error(
+        'spouse must be an instance of FamilyMember with different gender for pedigree analysis.',
+      );
+
     if (this.spouse || spouse.spouse)
       throw new Error(
         'pedigree analysis is not prepared for multiple marriages... divorce first in order to marry again.',
       );
 
-    if (!(spouse instanceof FamilyMember) || this._isMale === spouse._isMale)
-      throw new Error(
-        'spouse must be an instance of FamilyMember with different gender for pedigree analysis.',
-      );
     this._relationships.spouse = spouse;
     spouse._relationships.spouse = this;
     spouse._relationships.sons = this.sons; // share reference

--- a/lib/family-member/common.ts
+++ b/lib/family-member/common.ts
@@ -165,8 +165,8 @@ class FamilyMember {
   }
 
   _deleteParents() {
-    this._relationships.mom = undefined;
-    this._relationships.dad = undefined;
+    delete this._relationships.mom;
+    delete this._relationships.dad;
   }
 
   _hasChild(childObject: { [relationship: string]: FamilyMember }) {

--- a/lib/family-member/common.ts
+++ b/lib/family-member/common.ts
@@ -320,11 +320,11 @@ class FamilyMember {
   }
 
   get sons() {
-    return this._relationships.sons;
+    return { ...this._relationships.sons };
   }
 
   get daughters() {
-    return this._relationships.daughters;
+    return { ...this._relationships.daughters };
   }
 
   get brothers() {

--- a/lib/pedigree/index.ts
+++ b/lib/pedigree/index.ts
@@ -52,11 +52,6 @@ class Pedigree {
       0,
     );
 
-  static _getGenotype = (fatherAllele: Allele, motherAllele: Allele) =>
-    (motherAllele > fatherAllele // sort alleles ASC
-      ? `${fatherAllele}${motherAllele}`
-      : `${motherAllele}${fatherAllele}`) as Genotype;
-
   static _calculateAutosomalProbabilities(
     motherGenotypes: Genotype[],
     fatherGenotypes: Genotype[],
@@ -70,9 +65,9 @@ class Pedigree {
         const probabilities = {} as Probabilities;
         [...motherGenotype].forEach((motherAllele) =>
           [...fatherGenotype].forEach((fatherAllele) => {
-            const genotype = Pedigree._getGenotype(
-              fatherAllele as Allele,
+            const genotype = genotypes._fromAlleles(
               motherAllele as Allele,
+              fatherAllele as Allele,
             );
             if (probabilities[genotype] === undefined)
               probabilities[genotype] = 0;
@@ -99,11 +94,6 @@ class Pedigree {
     disease: CommonDisease, // use this for only XLinkedDisease
   ) {
     // pedigree analysis does not support sex chromosome aneuploidy yet
-    /**
-     * const countY = fatherGenotype.match(
-     * new RegExp(genotypes.NULL_ALLELE, 'g'),
-     * )?.length as number;
-     */
     const cases = {
       son: 2, // motherGenotype.length * countY,
       daughter: 2, // motherGenotype.length * (fatherGenotype.length - countY),
@@ -119,14 +109,13 @@ class Pedigree {
 
         [...motherGenotype].forEach((motherAllele) =>
           [...fatherGenotype].forEach((fatherAllele) => {
-            const genotype = Pedigree._getGenotype(
-              fatherAllele as Allele,
+            const genotype = genotypes._fromAlleles(
               motherAllele as Allele,
+              fatherAllele as Allele,
             );
-            const key =
-              genotype.indexOf(genotypes.NULL_ALLELE) === 1
-                ? 'son' // *_
-                : 'daughter'; // ** (X-linked) or __ (Y-linked)
+            const key = genotypes._isAlleleY(fatherAllele as Allele)
+              ? 'son'
+              : 'daughter';
             const { probabilities } = childrenInfo[key];
             if (probabilities[genotype] === undefined)
               probabilities[genotype] = 0;


### PR DESCRIPTION
개요
* 가족 관계 추가 시 검증 로직 강화
  * 부모님의 자손을 추가할 때 자손이 부모님 또는 부모님의 조상과 같은 경우 오류 발생
* 유전형, 유전 방식에 정확한 표기법 사용
* 오류 수정
  * X 열성 유전 질환의 표현형 범위 환산 과정이 틀림
  * 부모님 각각은 우성 대립유전자가 없을 수 있어도 동시에 없으면 안 되는 경우(aa/aa, xx/xY) 확률 결과값 제거